### PR TITLE
Fix choc_ergo config

### DIFF
--- a/keyboards/choc_ergo/config.h
+++ b/keyboards/choc_ergo/config.h
@@ -45,7 +45,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     { B5, B4, E6, D7, C6 }, \
     { B1, F7, F6, F5, F4 }, \
     { NO_PIN, NO_PIN, NO_PIN, B3, B2 } \
-} \
+}
 #define UNUSED_PINS
 
 /* COL2ROW, ROW2COL */


### PR DESCRIPTION
Hey there, a small backslash issue in `config.h` broke the build. Note that I haven't been able to test the firmware yet, but it does compile successfully now.